### PR TITLE
fixed deprecated error when compiling

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -7,7 +7,7 @@ const activeChainId = ChainId.Mumbai;
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
-    <ThirdwebProvider desiredChainId={activeChainId}>
+    <ThirdwebProvider activeChain={activeChainId}>
       <Component {...pageProps} />
     </ThirdwebProvider>
   );


### PR DESCRIPTION
When you compile it using `desiredChainId` the default used network will be Ethereum no matter what network you declare on `activeChainId`.